### PR TITLE
chore: remove php version limit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": ">=7.4 <8.4",
+        "php": ">=7.4",
         "psr/log": "~1.0 | ~2.0 | ~3.0",
         "struzik-vladislav/php-error-handler": "~1.0",
         "struzik-vladislav/epp-client": "^2.0"

--- a/src/StreamSocketConnection.php
+++ b/src/StreamSocketConnection.php
@@ -36,7 +36,7 @@ class StreamSocketConnection implements ConnectionInterface
      * Creating connection object to the EPP server.
      *
      * @param StreamSocketConfig $config connection settings
-     * @param LoggerInterface    $logger PSR-3 compatible logger
+     * @param LoggerInterface $logger PSR-3 compatible logger
      */
     public function __construct(StreamSocketConfig $config, LoggerInterface $logger)
     {
@@ -195,7 +195,7 @@ class StreamSocketConnection implements ConnectionInterface
     {
         $header = pack('N', strlen($xml) + self::HEADER_LENGTH);
 
-        return $header.$xml;
+        return $header . $xml;
     }
 
     /**


### PR DESCRIPTION
Is there a reason why PHP version cannot be higher than 8.4?
If not, I propose this PR to remove the limitation.

Thanks!